### PR TITLE
Add .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: go
+go:
+  - "1.12"
+os:
+  - linux
+notifications:
+  email: false


### PR DESCRIPTION
First simple version of .travis.yml file. It implicitly executes `go get ./...` command at install stage and `go test ./...` at script stage.